### PR TITLE
[chore] Update deprecated set-output

### DIFF
--- a/resources/views/action_yaml.blade.php
+++ b/resources/views/action_yaml.blade.php
@@ -60,7 +60,7 @@ jobs:
     - name: Get Composer Cache Directory 2
       id: composer-cache
       run: |
-        echo "::set-output name=dir::$(composer config cache-files-dir)"
+        echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
     - uses: actions/cache@v3
       id: actions-cache
       with:


### PR DESCRIPTION
Hello Roberto,

The command `::set-output` is being [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands).

This PR replaces the deprecated command with the new syntax: 

```yaml
- name: Get Composer Cache Directory 2
      id: composer-cache
      run: |
        echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
```

Greetings and thanks,

Dan

